### PR TITLE
Add badges to the readme and submit to Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,5 @@ notifications:
 #script:
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 #  - julia -e 'Pkg.clone(pwd()); Pkg.build("PkgBenchmark"); Pkg.test("PkgBenchmark"; coverage=true)'
+after_success:
+  - julia -e 'Pkg.add("Coverage"); cd(Pkg.dir("PkgBenchmark"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PkgBenchmark
 
+[![PkgBenchmark](http://pkg.julialang.org/badges/PkgBenchmark_0.5.svg)](http://pkg.julialang.org/?pkg=PkgBenchmark)
+[![PkgBenchmark](http://pkg.julialang.org/badges/PkgBenchmark_0.6.svg)](http://pkg.julialang.org/?pkg=PkgBenchmark)
 [![Build Status](https://travis-ci.org/JuliaCI/PkgBenchmark.jl.svg?branch=master)](https://travis-ci.org/JuliaCI/PkgBenchmark.jl)
 
 Convention and helper functions for package developers to track performance changes.
@@ -7,7 +9,7 @@ Convention and helper functions for package developers to track performance chan
 ```julia
 # installation
 
-Pkg.clone("git://github.com/shashi/PkgBenchmark.jl.git")
+Pkg.add("PkgBenchmark")
 ```
 
 ## Conventions


### PR DESCRIPTION
Currently the README recommends installation by cloning Shashi Gowda's repository. However, not only does this now live in the JuliaCI organization, but the package is registered, so folks should install it using `Pkg.add`. Since it's registered, I've added the PkgEvaluator badges to the README as well.

I also noticed that coverage information is not currently being submitted to Coveralls or Codecov. I enabled Coveralls submission in the Travis YAML, but a JuliaCI member will have to turn it on for the repo if it isn't already enabled.