### PR TITLE
use our own type for returning results from a benchmark

### DIFF
--- a/docs/src/man/run_benchmarks.md
+++ b/docs/src/man/run_benchmarks.md
@@ -6,6 +6,12 @@ Use `benchmarkpkg` to run benchmarks written using the convention above.
 benchmarkpkg
 ```
 
+The results of a benchmark is returned as a `BenchmarkResult`
+
+```@docs
+PkgBenchmark.BenchmarkResults
+```
+
 ## Comparing commits
 
 You can use `judge` to compare benchmark results of two versions of the package.

--- a/src/PkgBenchmark.jl
+++ b/src/PkgBenchmark.jl
@@ -10,6 +10,7 @@ export benchmarkpkg, judge, @benchgroup, @bench, writeresults, readresults
 
 include("util.jl")
 include("macros.jl")
+include("benchmarkresults.jl")
 include("runbenchmark.jl")
 include("judge.jl")
 

--- a/src/benchmarkresults.jl
+++ b/src/benchmarkresults.jl
@@ -1,0 +1,43 @@
+"""
+Stores the results from running the benchmarks on a package.
+
+The following (unexported) methods are defined on a `BenchmarkResults` (written below as `results`):
+
+* `name(results)::String` - the commit of the package benchmarked
+* `commit(results)::String` - the commit of the package benchmarked. If the package repository was dirty, the string `"dirty"` is returned.
+* `benchmarkgroup(results)::BenchmarkGroup` - a [`BenchmarkGroup`](https://github.com/JuliaCI/BenchmarkTools.jl/blob/master/doc/manual.md#the-benchmarkgroup-type)
+   contaning the results of the benchmark.
+* `date(results)::DateTime` - the time when the benchmarks were executed
+"""
+struct BenchmarkResults
+    name::String
+    commit::String
+    benchmarkgroup::BenchmarkGroup
+    date::DateTime
+end
+
+Base.:(==)(r1::BenchmarkResults, r2::BenchmarkResults) = r1.name           == r2.name           &&
+                                                         r1.commit         == r2.commit         &&
+                                                         r1.benchmarkgroup == r2.benchmarkgroup &&
+                                                         r1.date           == r2.date
+
+name(results::BenchmarkResults) = results.name
+commit(results::BenchmarkResults) = results.commit
+benchmarkgroup(results::BenchmarkResults) = results.benchmarkgroup
+date(results::BenchmarkResults) = results.date
+
+function Base.show(io::IO, results::BenchmarkResults)
+    if get(io, :limit, false)
+        print(io, "Benchmarkresults for ", results.name)
+    else
+        print_with_color(:nothing, "Benchmarkresults:\n"; bold = true)
+        println(io, "    Package: ", results.name)
+        println(io, "    Date: ", Base.Dates.format(results.date, "m u Y - H:M"))
+        println(io  , "    Package commit: ", results.commit)
+        iob = IOBuffer()
+        ioc = IOContext(iob)
+        show(ioc, MIME("text/plain"), results.benchmarkgroup)
+        println(io,   "    BenchmarkGroup:")
+        print(join("        " .* split(String(take!(iob)), "\n"), "\n"))
+    end
+end

--- a/src/benchmarkresults.jl
+++ b/src/benchmarkresults.jl
@@ -9,7 +9,7 @@ The following (unexported) methods are defined on a `BenchmarkResults` (written 
    contaning the results of the benchmark.
 * `date(results)::DateTime` - the time when the benchmarks were executed
 """
-struct BenchmarkResults
+immutable BenchmarkResults
     name::String
     commit::String
     benchmarkgroup::BenchmarkGroup

--- a/src/judge.jl
+++ b/src/judge.jl
@@ -1,24 +1,25 @@
+
 function _cached(pkg, ref; resultsdir=defaultresultsdir(pkg), kws...)
     if ref !== nothing
         sha = shastring(Pkg.dir(pkg), ref)
         file = joinpath(resultsdir, sha*".jld")
         if isfile(file)
             info("Reading results for $(sha[1:6]) from $resultsdir")
-            return readresults(file)
+            return benchmarkgroup(readresults(file))
         end
     end
 
-    benchmarkpkg(pkg, ref;resultsdir=resultsdir, kws...)
+    benchmarkgroup(benchmarkpkg(pkg, ref;resultsdir=resultsdir, kws...))
 end
 
 _repeat(x, n) = !isa(n, AbstractArray) && [x for _ in 1:n]
 _repeat(x::AbstractArray, n) = x
 
 function withresults(f::Function, pkg::String, refs;
-                                    use_saved=trues(length(refs)), kwargs...)
+                     use_saved=trues(length(refs)), kwargs...)
 
     use_saved = _repeat(use_saved, length(refs))
-    [s ? _cached(pkg, r; kwargs...) : benchmarkpkg(pkg, r; kwargs...)
+    [s ? _cached(pkg, r; kwargs...) : benchmarkgroup(benchmarkpkg(pkg, r; kwargs...))
         for (r,s) in zip(refs, use_saved)] |> f
 end
 
@@ -45,7 +46,7 @@ You can call `showall(results)` to see a comparison of all the benchmarks.
 
 - `f` - tuple of estimator functions - one each for `from_ref`, `to_ref` respectively
 - `use_saved` - similar tuple of flags, if false will not use saved results
-- for description of other keyword arguments, see `benchmarkpkg`
+- for description of other keyword arguments, see [`benchmarkpkg`](@ref)
 """
 function BenchmarkTools.judge(pkg::String, ref1::Union{String,Void}, ref2::String; f=minimum, judgekwargs=Dict(), kwargs...)
     fs = _repeat(f, 2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,7 +42,9 @@ end
 
     @testset "dict" begin
         results = benchmarkpkg("PkgBenchmark", script = joinpath(BENCHMARK_DIR, "benchmarks_dict.jl"))
-        test_structure(results)
+        test_structure(PkgBenchmark.benchmarkgroup(results))
+        @test PkgBenchmark.name(results) == "PkgBenchmark"
+        @test Dates.Year(PkgBenchmark.date(results)) == Dates.Year(now())
     end
 end
 
@@ -100,7 +102,7 @@ temp_pkg_dir(;tmp_dir = tmp_dir) do
     @test LibGit2.isdirty(repo)
     @test_throws ErrorException PkgBenchmark.benchmarkpkg(TEST_PACKAGE_NAME, "HEAD"; custom_loadpath=old_pkgdir)
     results = PkgBenchmark.benchmarkpkg(TEST_PACKAGE_NAME; custom_loadpath=old_pkgdir, resultsdir=tmp)
-    test_structure(results)
+    test_structure(PkgBenchmark.benchmarkgroup(results))
     @test !isfile(resfile)
 
     # Commit and benchmark non dirty repo
@@ -108,7 +110,7 @@ temp_pkg_dir(;tmp_dir = tmp_dir) do
     resfile = joinpath(tmp, "$(string(commitid)).jld")
     @test !LibGit2.isdirty(repo)
     results = PkgBenchmark.benchmarkpkg(TEST_PACKAGE_NAME, "HEAD"; custom_loadpath=old_pkgdir, resultsdir=tmp)
-    test_structure(results)
+    test_structure(PkgBenchmark.benchmarkgroup(results))
     @test isfile(resfile)
     @test readresults(resfile) == results
 


### PR DESCRIPTION
This returns our own `BenchmarkResults` from the benchmark routine instead of a "naked" BenchmarkGroup. This will be a breaking change but it is pretty much needed to allow for exporting metadata.

Fixes #24 since we can add arbitrary metadata to this object.

Will need to create an upgrade guide for next release.
