### PR TITLE
More readable result tables in markdown

### DIFF
--- a/src/benchmarkresults.jl
+++ b/src/benchmarkresults.jl
@@ -134,17 +134,22 @@ function export_markdown(io::IO, results::BenchmarkResults)
                 An empty cell means that the value was zero.
                 """)
 
-    print(io, """
-                | ID | time | GC time | memory | allocations |
-                |----|-----:|--------:|-------:|------------:|
-                """)
-
     entries = BenchmarkTools.leaves(benchmarkgroup(results))
     entries = entries[sortperm(map(x -> string(first(x)), entries))]
 
+    cw = [2, 4, 7, 6, 11]
+    for (ids, t) in entries
+        _update_col_widths!(cw, ids, t)
+    end
+
+    print(io, """
+                | ID$(" "^(cw[1]-2)) | time$(" "^(cw[2]-4)) | GC time$(" "^(cw[3]-7)) | memory$(" "^(cw[4]-6)) | allocations$(" "^(cw[5]-11)) |
+                |---$("-"^(cw[1]-2))-|-----$("-"^(cw[2]-4)):|--------$("-"^(cw[3]-7)):|-------$("-"^(cw[4]-6)):|------------$("-"^(cw[5]-11)):|
+                """)
+
 
     for (ids, t) in entries
-        println(io, _resultrow(ids, t))
+        println(io, _resultrow(ids, t, cw))
     end
     println(io)
     println(io, """

--- a/src/util.jl
+++ b/src/util.jl
@@ -60,20 +60,40 @@ _benchwarn(str) = print_with_color(Base.info_color(), STDOUT, "PkgBenchmark: ", 
 
 _idrepr(id) = (str = repr(id); str[searchindex(str, '['):end])
 _intpercent(p) = string(ceil(Int, p * 100), "%")
-_resultrow(ids, t::BenchmarkTools.Trial) = _resultrow(ids, minimum(t))
+_resultrow(ids, t::BenchmarkTools.Trial, col_widths) =
+    _resultrow(ids, minimum(t), col_widths)
 
-function _resultrow(ids, t::BenchmarkTools.TrialEstimate)
+_update_col_widths!(col_widths, ids, t::BenchmarkTools.Trial) =
+    _update_col_widths!(col_widths, ids, minimum(t))
+
+
+function _resultrow(ids, t::BenchmarkTools.TrialEstimate, col_widths)
     t_tol = _intpercent(BenchmarkTools.params(t).time_tolerance)
     m_tol = _intpercent(BenchmarkTools.params(t).memory_tolerance)
     timestr = BenchmarkTools.time(t) == 0 ? "" : string(BenchmarkTools.prettytime(BenchmarkTools.time(t)), " (", t_tol, ")")
     memstr = BenchmarkTools.memory(t) == 0 ? "" : string(BenchmarkTools.prettymemory(BenchmarkTools.memory(t)), " (", m_tol, ")")
     gcstr = BenchmarkTools.gctime(t) == 0 ? "" : BenchmarkTools.prettytime(BenchmarkTools.gctime(t))
     allocstr = BenchmarkTools.allocs(t) == 0 ? "" : string(BenchmarkTools.allocs(t))
-    return "| `$(_idrepr(ids))` | $(timestr) | $(gcstr) | $(memstr) | $(allocstr) |"
+    return "| $(rpad("`"*_idrepr(ids)*"`", col_widths[1])) | $(lpad(timestr, col_widths[2])) | $(lpad(gcstr, col_widths[3])) | $(lpad(memstr, col_widths[4])) | $(lpad(allocstr, col_widths[5])) |"
 end
 
 
-function _resultrow(ids, t::BenchmarkTools.TrialJudgement)
+function _update_col_widths!(col_widths, ids, t::BenchmarkTools.TrialEstimate)
+    t_tol = _intpercent(BenchmarkTools.params(t).time_tolerance)
+    m_tol = _intpercent(BenchmarkTools.params(t).memory_tolerance)
+    timestr = BenchmarkTools.time(t) == 0 ? "" : string(BenchmarkTools.prettytime(BenchmarkTools.time(t)), " (", t_tol, ")")
+    memstr = BenchmarkTools.memory(t) == 0 ? "" : string(BenchmarkTools.prettymemory(BenchmarkTools.memory(t)), " (", m_tol, ")")
+    gcstr = BenchmarkTools.gctime(t) == 0 ? "" : BenchmarkTools.prettytime(BenchmarkTools.gctime(t))
+    allocstr = BenchmarkTools.allocs(t) == 0 ? "" : string(BenchmarkTools.allocs(t))
+    idrepr = "`"*_idrepr(ids)*"`"
+    for (i, s) in enumerate((idrepr, timestr, gcstr, memstr, allocstr))
+        w = length(s)
+        if (w > col_widths[i]) col_widths[i] = w end
+    end
+end
+
+
+function _resultrow(ids, t::BenchmarkTools.TrialJudgement, col_widths)
     t_tol = _intpercent(BenchmarkTools.params(t).time_tolerance)
     m_tol = _intpercent(BenchmarkTools.params(t).memory_tolerance)
     t_ratio = @sprintf("%.2f", BenchmarkTools.time(BenchmarkTools.ratio(t)))
@@ -82,7 +102,24 @@ function _resultrow(ids, t::BenchmarkTools.TrialJudgement)
     m_mark = _resultmark(BenchmarkTools.memory(t))
     timestr = "$(t_ratio) ($(t_tol)) $(t_mark)"
     memstr = "$(m_ratio) ($(m_tol)) $(m_mark)"
-    return "| `$(_idrepr(ids))` | $(timestr) | $(memstr) |"
+    return "| $(rpad("`"*_idrepr(ids)*"`", col_widths[1])) | $(lpad(timestr, col_widths[2])) | $(lpad(memstr, col_widths[3])) |"
+end
+
+
+function _update_col_widths!(col_widths, ids, t::BenchmarkTools.TrialJudgement)
+    t_tol = _intpercent(BenchmarkTools.params(t).time_tolerance)
+    m_tol = _intpercent(BenchmarkTools.params(t).memory_tolerance)
+    t_ratio = @sprintf("%.2f", BenchmarkTools.time(BenchmarkTools.ratio(t)))
+    m_ratio =  @sprintf("%.2f", BenchmarkTools.memory(BenchmarkTools.ratio(t)))
+    t_mark = _resultmark(BenchmarkTools.time(t))
+    m_mark = _resultmark(BenchmarkTools.memory(t))
+    timestr = "$(t_ratio) ($(t_tol)) $(t_mark)"
+    memstr = "$(m_ratio) ($(m_tol)) $(m_mark)"
+    idrepr = "`"*_idrepr(ids)*"`"
+    for (i, s) in enumerate((idrepr, timestr, memstr))
+        w = length(s)
+        if (w > col_widths[i]) col_widths[i] = w end
+    end
 end
 
 _resultmark(sym::Symbol) = sym == :regression ? _REGRESS_MARK : (sym == :improvement ? _IMPROVE_MARK : "")


### PR DESCRIPTION
The result tables are written to markdown with aligned columns, so that the resulting file is human-readable without having to convert it to html. 

This follows [Markdown's intended philosophy](https://daringfireball.net/projects/markdown/syntax#philosophy):
"Readability, however, is emphasized above all else. A Markdown-formatted document should be publishable as-is, as plain text, without looking like it’s been marked up with tags or formatting instructions."

This commit also implements the missing method `export_markdown(::String, ::BenchmarkJudgement)` that allows to write the result of `judge` directly to a file.

Closes #59.