### PR TITLE
FIX: Replace `m` with `d` in `Base.Dates.format`

### DIFF
--- a/src/benchmarkjudgement.jl
+++ b/src/benchmarkjudgement.jl
@@ -27,8 +27,8 @@ function Base.show(io::IO, judgement::BenchmarkJudgement)
     target, base = judgement.target_results, judgement.baseline_results
     print(io, "Benchmarkjudgement (target / baseline):\n")
     println(io, "    Package: ", target.name)
-    println(io, "    Dates: ", Base.Dates.format(target.date,  "m u Y - H:M"), " / ",
-                               Base.Dates.format(base.date, "m u Y - H:M"))
+    println(io, "    Dates: ", Base.Dates.format(target.date,  "d u Y - H:M"), " / ",
+                               Base.Dates.format(base.date, "d u Y - H:M"))
     println(io, "    Package commits: ", target.commit[1:min(length(target.commit), 6)], " / ",
                                         base.commit[1:min(length(base.commit), 6)])
     println(io, "    Julia commits: ", target.julia_commit[1:6], " / ",

--- a/src/benchmarkresults.jl
+++ b/src/benchmarkresults.jl
@@ -35,7 +35,7 @@ Base.versioninfo(results::BenchmarkResults) = results.vinfo
 function Base.show(io::IO, results::BenchmarkResults)
     print(io, "Benchmarkresults:\n")
     println(io, "    Package: ", results.name)
-    println(io, "    Date: ", Base.Dates.format(results.date, "m u Y - HH:MM"))
+    println(io, "    Date: ", Base.Dates.format(results.date, "d u Y - HH:MM"))
     println(io, "    Package commit: ", results.commit[1:min(length(results.commit), 6)])
     println(io, "    Julia commit: ", results.julia_commit[1:6])
     iob = IOBuffer()


### PR DESCRIPTION
I suppose you wanted to write `d` instead of `m` in https://github.com/JuliaCI/PkgBenchmark.jl/blob/d3e7a0de30c5a1346eb827c512fa7e4111fcd825/src/benchmarkjudgement.jl#L30-L31

With `master`:

```jl
julia> jud
Benchmarkjudgement (target / baseline):
    Package: Games
    Dates: 2 Feb 2018 - 9:41 / 2 Feb 2018 - 9:41
    Package commits: e3086a / d6682d
    Julia commits: d386e4 / d386e4


julia> jud.baseline_results.date
2018-02-21T09:41:49.563
```

With this PR:

```jl
julia> jud
Benchmarkjudgement (target / baseline):
    Package: Games
    Dates: 21 Feb 2018 - 11:5 / 21 Feb 2018 - 11:5
    Package commits: e3086a / d6682d
    Julia commits: d386e4 / d386e4
```