### PR TITLE
Add support for writecsv method

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,6 +10,7 @@ makedocs(
         "run_benchmarks.md",
         "comparing_commits.md",
         "export_markdown.md",
+        "export_csv.md",
         "Reference" => "ref.md",
     ]
 )

--- a/docs/src/export_csv.md
+++ b/docs/src/export_csv.md
@@ -1,0 +1,48 @@
+# Export to CSV
+
+For analyzing the results of a benchmark more quantitatively, both [`PkgBenchmark.BenchmarkResults`](@ref) and  [`PkgBenchmark.BenchmarkJudgement`](@ref) may be written to a CSV file, using `writecsv`.
+
+If the benchmark suite uses nested benchmark groups, such that the ID for each result is a vector, the components of this ID vector go into separate columns in the CSV file. For example, consider a `BenchmarkResult` for which [`export_markdown`](@ref) generates the following table:
+
+```
+| ID                                                                    | time            | GC time | memory          | allocations |
+|-----------------------------------------------------------------------|----------------:|--------:|----------------:|------------:|
+| `["trigonometry", "circular", "(\"cos\", 0.0)"]`                      |  35.000 ns (5%) |         |                 |             |
+| `["trigonometry", "circular", "(\"cos\", π = 3.1415926535897...)"]`   |  73.000 ns (5%) |         |                 |             |
+| `["trigonometry", "circular", "(\"sin\", 0.0)"]`                      |  35.000 ns (5%) |         |                 |             |
+| `["trigonometry", "circular", "(\"sin\", π = 3.1415926535897...)"]`   |  76.000 ns (5%) |         |                 |             |
+| `["trigonometry", "circular", "(\"tan\", 0.0)"]`                      |  35.000 ns (5%) |         |                 |             |
+| `["trigonometry", "circular", "(\"tan\", π = 3.1415926535897...)"]`   |  91.000 ns (5%) |         |                 |             |
+| `["trigonometry", "hyperbolic", "(\"cos\", 0.0)"]`                    |  32.000 ns (5%) |         |                 |             |
+| `["trigonometry", "hyperbolic", "(\"cos\", π = 3.1415926535897...)"]` |  75.000 ns (5%) |         |                 |             |
+| `["trigonometry", "hyperbolic", "(\"sin\", 0.0)"]`                    |  35.000 ns (5%) |         |                 |             |
+| `["trigonometry", "hyperbolic", "(\"sin\", π = 3.1415926535897...)"]` |  75.000 ns (5%) |         |                 |             |
+| `["trigonometry", "hyperbolic", "(\"tan\", 0.0)"]`                    |  35.000 ns (5%) |         |                 |             |
+| `["trigonometry", "hyperbolic", "(\"tan\", π = 3.1415926535897...)"]` |  90.000 ns (5%) |         |                 |             |
+| `["utf8", "join"]`                                                    | 243.752 ms (5%) |         | 128.00 MiB (1%) |          20 |
+| `["utf8", "plots", "fnplot"]`                                         | 279.984 μs (5%) |         |  38.69 KiB (1%) |         937 |
+| `["utf8", "replace"]`                                                 | 249.997 μs (5%) |         |  12.06 KiB (1%) |           6 |
+```
+
+The equivalent CSV data would be this:
+
+```
+ID1,ID2,ID3,time,time tol,GC time,memory,mem tol,allocs
+utf8,join,,243751509,0.05,0,134218096,0.01,20
+utf8,plots,fnplot,279984,0.05,0,39616,0.01,937
+utf8,replace,,249997,0.05,0,12352,0.01,6
+trigonometry,circular,"(""tan"", π = 3.1415926535897...)",91,0.05,0,0,0.01,0
+trigonometry,circular,"(""cos"", π = 3.1415926535897...)",73,0.05,0,0,0.01,0
+trigonometry,circular,"(""sin"", π = 3.1415926535897...)",76,0.05,0,0,0.01,0
+trigonometry,circular,"(""sin"", 0.0)",35,0.05,0,0,0.01,0
+trigonometry,circular,"(""tan"", 0.0)",35,0.05,0,0,0.01,0
+trigonometry,circular,"(""cos"", 0.0)",35,0.05,0,0,0.01,0
+trigonometry,hyperbolic,"(""tan"", π = 3.1415926535897...)",90,0.05,0,0,0.01,0
+trigonometry,hyperbolic,"(""cos"", π = 3.1415926535897...)",75,0.05,0,0,0.01,0
+trigonometry,hyperbolic,"(""sin"", π = 3.1415926535897...)",75,0.05,0,0,0.01,0
+trigonometry,hyperbolic,"(""sin"", 0.0)",35,0.05,0,0,0.01,0
+trigonometry,hyperbolic,"(""tan"", 0.0)",35,0.05,0,0,0.01,0
+trigonometry,hyperbolic,"(""cos"", 0.0)",32,0.05,0,0,0.01,0
+```
+
+Note that time measurements in the CSV are always in nanoseconds, and memory measurements in bytes. Also for `BenchmarkJudgement`, the CSV will contain the results for *all* benchmarks, whereas the markdown report will only include benchmarks for which there was a significant change.

--- a/src/PkgBenchmark.jl
+++ b/src/PkgBenchmark.jl
@@ -5,8 +5,10 @@ module PkgBenchmark
 using BenchmarkTools
 using JSON
 using ProgressMeter
+import Base.DataFmt: writecsv
 
 export benchmarkpkg, judge, writeresults, readresults, export_markdown
+export writecsv
 export BenchmarkConfig, BenchmarkResults, BenchmarkJudgement
 
 include("benchmarkconfig.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -137,6 +137,14 @@ temp_pkg_dir(;tmp_dir = tmp_dir) do
     @test r.commit == results.commit
     rm(tmp)
 
+    # Write the benchmark result to a CSV file and check the result
+    csvfilename = tempname()
+    writecsv(csvfilename, results)
+    csvdata = readcsv(csvfilename)
+    rm(csvfilename)
+    @test size(csvdata) == (16, 9)
+    @test csvdata[5, 3] == "(\"tan\", π = 3.1415926535897...)"
+
     # Make a dummy commit and test comparing HEAD and HEAD~
     touch(joinpath(testpkg_path, "dummy"))
     LibGit2.add!(repo, "dummy")
@@ -148,5 +156,12 @@ temp_pkg_dir(;tmp_dir = tmp_dir) do
         export_markdown(STDOUT, judgement)
         judgement = judge(TEST_PACKAGE_NAME, "HEAD", custom_loadpath=old_pkgdir)
         test_structure(PkgBenchmark.benchmarkgroup(judgement))
+        # Write the benchmark result to a CSV file and check the result
+        csvfilename = tempname()
+        writecsv(csvfilename, judgement)
+        csvdata = readcsv(csvfilename)
+        rm(csvfilename)
+        @test size(csvdata) == (16, 7)
+        @test csvdata[5, 3] == "(\"tan\", π = 3.1415926535897...)"
     end
 end


### PR DESCRIPTION
The patch adds full support for the `writecsv` function, for both `BenchmarkResults` and `BenchmarkJudgement`. There is a test for the expected behavior, and a new section in the documentation.

This closes #65