### PR TITLE
Fix script detection and env handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 docs/build
 benchmark/tune.json
 deps/already_showed
+deps/build.log

--- a/src/runbenchmark.jl
+++ b/src/runbenchmark.jl
@@ -57,7 +57,7 @@ function benchmarkpkg(
         script = joinpath(pkgdir, "benchmark", "benchmarks.jl")
     elseif !isabspath(script)
         script = joinpath(pkgdir, script)
-        end
+    end
 
     if !isfile(script)
         error("benchmark script at $script not found")
@@ -143,7 +143,8 @@ function _runbenchmark(file::String, output::String, benchmarkconfig::BenchmarkC
 
     target_env = [k => v for (k, v) in benchmarkconfig.env]
     withenv(target_env...) do
-        run(`$(benchmarkconfig.juliacmd) --depwarn=no --code-coverage=$coverage $color $compilecache -e $exec_str`)
+        env_to_use = dirname(Pkg.Types.Context().env.project_file)
+        run(`$(benchmarkconfig.juliacmd) --project=$env_to_use --depwarn=no --code-coverage=$coverage $color $compilecache -e $exec_str`)
     end
     return JSON.parsefile(output)
 end

--- a/src/runbenchmark.jl
+++ b/src/runbenchmark.jl
@@ -40,15 +40,27 @@ function benchmarkpkg(
     )
     target = BenchmarkConfig(target)
 
-    # Locate script
-    pkgdir = joinpath(dirname(pkg), "..")
-    if script === nothing
-        bench_file = joinpath(pkgdir, "benchmark", "benchmarks.jl")
-        if isfile(bench_file)
-            script = bench_file
+    pkgfile_from_pkgname = Base.locate_package(Base.identify_package(pkg))
+
+    if pkgfile_from_pkgname===nothing
+        if isdir(pkg)
+            pkgdir = pkg
         else
-            error("bencmark script at \"$(abspath(bench_file))\" not found")
+            error("No package '$pkg' found.")
         end
+    else
+        pkgdir = normpath(joinpath(dirname(pkgfile_from_pkgname), ".."))
+    end
+
+    # Locate script
+    if script === nothing
+        script = joinpath(pkgdir, "benchmark", "benchmarks.jl")
+    elseif !isabspath(script)
+        script = joinpath(pkgdir, script)
+        end
+
+    if !isfile(script)
+        error("benchmark script at $script not found")
     end
 
     # Locate pacakge


### PR DESCRIPTION
This PR does two things: 1) it re-enables calling ``benchmarkpkg`` with purely a package name and 2) it runs the benchmark in the same environment from which ``benchmarkpkg`` is called.

@fredrikekre would be great if you could review this because this is changing some of the code you changed for the 0.7/1.0 update.

@KristofferC could you review whether my package handling code here is correct?