### PR TITLE
Fix benchmarkpkg(path) for Julia 1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ os:
 
 julia:
   - 1.0
+  - 1.1
+  - 1.2
   - nightly
 
 matrix:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ julia> Pkg.add("PkgBenchmark")
 
 ## Project Status
 
-The package is tested against Julia `v1.0` and `v1.1` on Linux and macOS.
+The package is tested against Julia `v1.0` to `v1.2` on Linux and macOS.
 
 ## Contributing and Questions
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ environment:
   matrix:
   - julia_version: 1.0
   - julia_version: 1.1
+  - julia_version: 1.2
   - julia_version: nightly
 
 platform:

--- a/src/runbenchmark.jl
+++ b/src/runbenchmark.jl
@@ -44,7 +44,8 @@ function benchmarkpkg(
     )
     target = BenchmarkConfig(target)
 
-    pkgfile_from_pkgname = Base.locate_package(Base.identify_package(pkg))
+    pkgid = Base.identify_package(pkg)
+    pkgfile_from_pkgname = pkgid === nothing ? nothing : Base.locate_package(pkgid)
 
     if pkgfile_from_pkgname===nothing
         if isdir(pkg)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,6 @@ function temp_pkg_dir(fn::Function; tmp_dir=joinpath(tempdir(), randstring()),
     # Used in tests below to set up and tear down a sandboxed package directory
     try
         # TODO(nhdaly): Is this right??
-        Pkg.generate(tmp_dir)
         Pkg.activate(tmp_dir)
         Pkg.instantiate()
         fn()


### PR DESCRIPTION
The case `pkg` is not a package name must be handled before passing a
`Union{Nothing, PkgId}` to `Base.identify_package` as Julia >= 1.2
does not have `locate_package(::Nothing)`.