### PR TITLE
fix documentation deployment

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,7 @@ using Documenter, PkgBenchmark
 
 makedocs(
     modules = [PkgBenchmark],
-    format = :html,
+    format = Documenter.HTML(),
     sitename = "PkgBenchmark.jl",
     pages = Any[
         "Home" => "index.md",
@@ -16,8 +16,4 @@ makedocs(
 
 deploydocs(
     repo = "github.com/JuliaCI/PkgBenchmark.jl.git",
-    target = "build",
-    julia = "0.6",
-    deps = nothing,
-    make = nothing
 )


### PR DESCRIPTION
The documentation site hasn't been deployed since last year, because `Documenter` has been updated.
Error message from the [CI of #85](https://travis-ci.org/JuliaCI/PkgBenchmark.jl/jobs/565243046#L1083):
```
1083┌ Warning: the `julia` keyword argument to `Documenter.deploydocs` is removed. Use Travis Build Stages for determining from where to deploy instead. See the section about Hosting in the Documenter manual for more details.
1084│   caller = ip:0x0
1085└ @ Core :-1
1086[ Info: skipping docs deployment.
```
This PR fixes `deploydocs()` and also updates  `makedocs()` as `format=:html` is deprecated.