### PR TITLE
Add an option to show all results (not just significant results) when exporting`BenchmarkJudgement` to Markdown

### DIFF
--- a/src/benchmarkjudgement.jl
+++ b/src/benchmarkjudgement.jl
@@ -41,7 +41,7 @@ function export_markdown(file::String, results::BenchmarkJudgement; kwargs...)
     end
 end
 
-function export_markdown(io::IO, judgement::BenchmarkJudgement; allrows::Bool = false)
+function export_markdown(io::IO, judgement::BenchmarkJudgement; export_invariants::Bool = false)
     target, baseline = judgement.target_results, judgement.baseline_results
     function env_strs(res)
         return if isempty(benchmarkconfig(res).env)
@@ -90,7 +90,7 @@ function export_markdown(io::IO, judgement::BenchmarkJudgement; allrows::Bool = 
         _update_col_widths!(cw, ids, t)
     end
 
-    if allrows
+    if export_invariants
         print(io, """
                     ## Results
                     A ratio greater than `1.0` denotes a possible regression (marked with $(_REGRESS_MARK)), while a ratio less

--- a/src/benchmarkjudgement.jl
+++ b/src/benchmarkjudgement.jl
@@ -35,13 +35,13 @@ function Base.show(io::IO, judgement::BenchmarkJudgement)
                                        base.julia_commit[1:6])
 end
 
-function export_markdown(file::String, results::BenchmarkJudgement)
+function export_markdown(file::String, results::BenchmarkJudgement; kwargs...)
     open(file, "w") do f
-        export_markdown(f, results)
+        export_markdown(f, results; kwargs...)
     end
 end
 
-function export_markdown(io::IO, judgement::BenchmarkJudgement)
+function export_markdown(io::IO, judgement::BenchmarkJudgement; allrows::Bool = false)
     target, baseline = judgement.target_results, judgement.baseline_results
     function env_strs(res)
         return if isempty(benchmarkconfig(res).env)
@@ -90,20 +90,35 @@ function export_markdown(io::IO, judgement::BenchmarkJudgement)
         _update_col_widths!(cw, ids, t)
     end
 
-    print(io, """
-                ## Results
-                A ratio greater than `1.0` denotes a possible regression (marked with $(_REGRESS_MARK)), while a ratio less
-                than `1.0` denotes a possible improvement (marked with $(_IMPROVE_MARK)). Only significant results - results
-                that indicate possible regressions or improvements - are shown below (thus, an empty table means that all
-                benchmark results remained invariant between builds).
+    if allrows
+        print(io, """
+                    ## Results
+                    A ratio greater than `1.0` denotes a possible regression (marked with $(_REGRESS_MARK)), while a ratio less
+                    than `1.0` denotes a possible improvement (marked with $(_IMPROVE_MARK)). All results are shown below.
 
-                | ID$(" "^(cw[1]-2)) | time ratio$(" "^(cw[2]-10)) | memory ratio$(" "^(cw[3]-12)) |
-                |---$("-"^(cw[1]-2))-|-----------$("-"^(cw[2]-10))-|-------------$("-"^(cw[3]-12))-|
-                """)
+                    | ID$(" "^(cw[1]-2)) | time ratio$(" "^(cw[2]-10)) | memory ratio$(" "^(cw[3]-12)) |
+                    |---$("-"^(cw[1]-2))-|-----------$("-"^(cw[2]-10))-|-------------$("-"^(cw[3]-12))-|
+                    """)
 
-    for (ids, t) in entries
-        if BenchmarkTools.isregression(t) || BenchmarkTools.isimprovement(t)
+        for (ids, t) in entries
             println(io, _resultrow(ids, t, cw))
+        end
+    else
+        print(io, """
+                    ## Results
+                    A ratio greater than `1.0` denotes a possible regression (marked with $(_REGRESS_MARK)), while a ratio less
+                    than `1.0` denotes a possible improvement (marked with $(_IMPROVE_MARK)). Only significant results - results
+                    that indicate possible regressions or improvements - are shown below (thus, an empty table means that all
+                    benchmark results remained invariant between builds).
+
+                    | ID$(" "^(cw[1]-2)) | time ratio$(" "^(cw[2]-10)) | memory ratio$(" "^(cw[3]-12)) |
+                    |---$("-"^(cw[1]-2))-|-----------$("-"^(cw[2]-10))-|-------------$("-"^(cw[3]-12))-|
+                    """)
+
+        for (ids, t) in entries
+            if BenchmarkTools.isregression(t) || BenchmarkTools.isimprovement(t)
+                println(io, _resultrow(ids, t, cw))
+            end
         end
     end
 

--- a/src/benchmarkresults.jl
+++ b/src/benchmarkresults.jl
@@ -85,10 +85,16 @@ function readresults(file::String)
 end
 
 """
-    export_markdown(file::String, results::Union{BenchmarkResults, BenchmarkJudgement})
-    export_markdown(io::IO,       results::Union{BenchmarkResults, BenchmarkJudgement})
+    export_markdown(file::String, results::BenchmarkResults)
+    export_markdown(io::IO,       results::BenchmarkResults)
+    export_markdown(file::String, results::BenchmarkJudgement; export_invariants=false)
+    export_markdown(io::IO,       results::BenchmarkJudgement; export_invariants=false)
 
 Writes the `results` to `file` or `io` in markdown format.
+
+When exporting a `BenchmarkJudgement`, by default only the results corresponding to
+possible regressions or improvements will be included. To also export the invariant
+results, set `export_invariants=true`.
 
 See also: [`BenchmarkResults`](@ref), [`BenchmarkJudgement`](@ref)
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -163,8 +163,8 @@ temp_pkg_dir(;tmp_dir = tmp_dir) do
         judgement = judge(TEST_PACKAGE_NAME, "HEAD~", "HEAD", custom_loadpath=old_pkgdir)
         test_structure(PkgBenchmark.benchmarkgroup(judgement))
         export_markdown(stdout, judgement)
-        export_markdown(stdout, judgement; allrows = false)
-        export_markdown(stdout, judgement; allrows = true)
+        export_markdown(stdout, judgement; export_invariants = false)
+        export_markdown(stdout, judgement; export_invariants = true)
         judgement = judge(TEST_PACKAGE_NAME, "HEAD", custom_loadpath=old_pkgdir)
         test_structure(PkgBenchmark.benchmarkgroup(judgement))
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -163,6 +163,8 @@ temp_pkg_dir(;tmp_dir = tmp_dir) do
         judgement = judge(TEST_PACKAGE_NAME, "HEAD~", "HEAD", custom_loadpath=old_pkgdir)
         test_structure(PkgBenchmark.benchmarkgroup(judgement))
         export_markdown(stdout, judgement)
+        export_markdown(stdout, judgement; allrows = false)
+        export_markdown(stdout, judgement; allrows = true)
         judgement = judge(TEST_PACKAGE_NAME, "HEAD", custom_loadpath=old_pkgdir)
         test_structure(PkgBenchmark.benchmarkgroup(judgement))
     end


### PR DESCRIPTION
## Summary

This pull request adds the ability to show all results (not just potential improvements and regressions) when exporting a `BenchmarkJudgement` to Markdown.

## Description

This pull request adds the `export_invariants::Bool` keyword argument to the `export_markdown(file::String, results::BenchmarkJudgement)` and `export_markdown(io::IO, judgement::BenchmarkJudgement)` methods.

The default value is `export_invariants = false`, which preserves the current behavior.