### PR TITLE
Add progressoptions keyword argument for configuring progress bars

### DIFF
--- a/src/runbenchmark.jl
+++ b/src/runbenchmark.jl
@@ -199,7 +199,7 @@ end
 
 
 function _tune!(group::BenchmarkTools.BenchmarkGroup; verbose::Bool = false, root = true,
-                prog = _progress(length(BenchmarkTools.leaves(group)); desc = "Tuning: "), hierarchy = [], kwargs...)
+                prog = Progress(length(BenchmarkTools.leaves(group)); desc = "Tuning: "), hierarchy = [], kwargs...)
     BenchmarkTools.gcscrub() # run GC before running group, even if individual benchmarks don't manually GC
     i = 1
     for id in keys(group)
@@ -222,7 +222,7 @@ function _tune!(b::BenchmarkTools.Benchmark, p::BenchmarkTools.Parameters = b.pa
 end
 
 function _run(group::BenchmarkTools.BenchmarkGroup, args...;
-              prog = _progress(length(BenchmarkTools.leaves(group)); desc = "Benchmarking: "), hierarchy = [], kwargs...)
+              prog = Progress(length(BenchmarkTools.leaves(group)); desc = "Benchmarking: "), hierarchy = [], kwargs...)
     result = similar(group)
     BenchmarkTools.gcscrub() # run GC before running group, even if individual benchmarks don't manually GC
     i = 1
@@ -242,14 +242,3 @@ function _run(b::BenchmarkTools.Benchmark, p::BenchmarkTools.Parameters = b.para
     end
     return res
 end
-
-is_in_ci() = lowercase(get(ENV, "CI", "false")) == "true"
-# Many CI services set environment variable `CI` to `true`:
-# https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
-# https://www.appveyor.com/docs/environment-variables/
-# https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
-
-_progress(n; kwargs...) = Progress(n; dt=is_in_ci() ? 60 * 9.0 : 0.1, kwargs...)
-# Use interval of 9 minute in CI to avoid build timeout in Travis
-# (which defaults to 10 minutes):
-# https://docs.travis-ci.com/user/customizing-the-build/#build-timeouts


### PR DESCRIPTION
Using PkgBenchmark in CI can be much nicer if it auto-detects that it is invoked in CI and avoid printing progress bars.  This would reduce log output and so reporting part is not truncated (or more like truncated not too early).

So, I suggest to look at `ENV["CI"]` and avoid printing progress bar if it is `"true"`.  Note that we can't use `stderr isa TTY` because it is `true` in Travis.

Here is an example output in CI:

* Before: https://travis-ci.com/tkf/Transducers.jl/jobs/235249351#L300
* After: https://travis-ci.com/tkf/Transducers.jl/jobs/235256996#L300

Note: click the line `$ julia -e 'using Run; Run.script("benchmark/runjudge.jl")'` to see the progress bar output.
