### PR TITLE
Compatibility with git submodules

### DIFF
--- a/src/runbenchmark.jl
+++ b/src/runbenchmark.jl
@@ -74,7 +74,7 @@ function benchmarkpkg(
     # Locate pacakge
     tunefile = joinpath(pkgdir, "benchmark", "tune.json")
 
-    isgitrepo = isdir(joinpath(pkgdir, ".git"))
+    isgitrepo = ispath(joinpath(pkgdir, ".git"))
     if isgitrepo
         isdirty = LibGit2.with(LibGit2.isdirty, LibGit2.GitRepo(pkgdir))
         original_sha = _shastring(pkgdir, "HEAD")


### PR DESCRIPTION
If benchmarking within a git submodule, the `.git` "directory" is just a file.
```
> cat .git
gitdir: ../.git/modules/mysubmodule
```