### PR TITLE
Only update the root /Manifest.toml

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -21,4 +21,4 @@ jobs:
       - name: CompatHelper.main()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: julia -e 'using CompatHelper; CompatHelper.main( (; registries) -> CompatHelper._update_manifests([pwd()]; registries = registries) )'
+        run: julia -e 'using CompatHelper; CompatHelper.main( (; registries) -> CompatHelper._update_manifests(pwd(); registries = registries) )'

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -21,4 +21,5 @@ jobs:
       - name: CompatHelper.main()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: julia -e 'using CompatHelper; CompatHelper.main()'
+        run: julia -e 'using CompatHelper; CompatHelper.main( (; registries) -> CompatHelper._update_manifests([pwd()]; registries = registries) )'
+

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -22,4 +22,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: julia -e 'using CompatHelper; CompatHelper.main( (; registries) -> CompatHelper._update_manifests([pwd()]; registries = registries) )'
-


### PR DESCRIPTION
This tells CompatHelper that it is allowed to update `/Manifest.toml`, but it is not allowed to update any other manifests, such as `/docs/Manifest.toml`.

cc: @KristofferC 

This is the same thing we did for PackageCompilerX.jl.