### PR TITLE
Allow package module to be used for benchmarking

### DIFF
--- a/src/judge.jl
+++ b/src/judge.jl
@@ -1,12 +1,12 @@
 """
-    judge(pkg::String,
+    judge(pkg::Union{Module, String},
           [target]::Union{String, BenchmarkConfig},
           baseline::Union{String, BenchmarkConfig};
           kwargs...)
 
 **Arguments**:
 
-- `pkg` - Package name or directory to benchmark.
+- `pkg` - Package to benchmark. Either a package module, name, or directory.
 - `target` - What do judge, given as a git id or a [`BenchmarkConfig`](@ref). If skipped, use the current state of the package repo.
 - `baseline` - The commit / [`BenchmarkConfig`](@ref) to compare `target` against.
 
@@ -21,7 +21,7 @@ The remaining keyword arguments are passed to [`benchmarkpkg`](@ref)
 
 Returns a [`BenchmarkJudgement`](@ref)
 """
-function BenchmarkTools.judge(pkg::String, target::Union{BenchmarkConfig,String}, baseline::Union{BenchmarkConfig,String};
+function BenchmarkTools.judge(pkg::Union{Module,String}, target::Union{BenchmarkConfig,String}, baseline::Union{BenchmarkConfig,String};
                               f=minimum, judgekwargs=Dict(), kwargs...)
 
     target, baseline = BenchmarkConfig(target), BenchmarkConfig(baseline)
@@ -32,7 +32,7 @@ function BenchmarkTools.judge(pkg::String, target::Union{BenchmarkConfig,String}
     return judge(group_target, group_baseline, f; judgekwargs=judgekwargs)
 end
 
-function BenchmarkTools.judge(pkg::String, baseline::Union{BenchmarkConfig,String}; kwargs...)
+function BenchmarkTools.judge(pkg::Union{Module,String}, baseline::Union{BenchmarkConfig,String}; kwargs...)
     judge(pkg, BenchmarkConfig(), baseline; kwargs...)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,9 @@ end
 
 const BENCHMARK_DIR = joinpath(@__DIR__, "..", "benchmark")
 
+# A module which isn't a package
+module Empty end
+
 function temp_pkg_dir(fn::Function; tmp_dir=joinpath(tempdir(), randstring()),
         remove_tmp_dir::Bool=true, initialize::Bool=true)
     # Used in tests below to set up and tear down a sandboxed package directory
@@ -221,4 +224,9 @@ end
 
 @testset "doctest" begin
     doctest(PkgBenchmark)
+end
+
+@testset "package module" begin
+    @test_throws ArgumentError benchmarkpkg(Empty)
+    @test benchmarkpkg(PkgBenchmark) isa BenchmarkResults
 end


### PR DESCRIPTION
An alternate fix for: https://github.com/JuliaCI/PkgBenchmark.jl/issues/111