### PR TITLE
Fix propagation of Julia flags

### DIFF
--- a/src/runbenchmark.jl
+++ b/src/runbenchmark.jl
@@ -228,7 +228,7 @@ function _runbenchmark(file::String, output::String, benchmarkconfig::BenchmarkC
         )
         """
 
-    # Propogate Julia flags passed into the current Julia process
+    # Propagate Julia flags passed into the current Julia process
     color = if VERSION < v"1.5.0-DEV.576"  # https://github.com/JuliaLang/julia/pull/35324
         Base.have_color ? `--color=yes` : `--color=no`
     else

--- a/src/runbenchmark.jl
+++ b/src/runbenchmark.jl
@@ -205,17 +205,7 @@ end
 function _runbenchmark(file::String, output::String, benchmarkconfig::BenchmarkConfig, tunefile::String;
                        retune = false, custom_loadpath = nothing, runoptions = NamedTuple(),
                        logger_factory = nothing)
-    color = Base.have_color ? "--color=yes" : "--color=no"
-    compilecache = "--compiled-modules=" * (Bool(Base.JLOptions().use_compiled_modules) ? "yes" : "no")
     _file, _output, _tunefile, _custom_loadpath = map(escape_string, (file, output, tunefile, custom_loadpath))
-    codecov_option = Base.JLOptions().code_coverage
-    coverage = if codecov_option == 0
-        "none"
-    elseif codecov_option == 1
-        "user"
-    else
-        "all"
-    end
     logger_factory_path = if logger_factory === nothing
         # Default to `TerminalLoggers.TerminalLogger`; load via
         # `PkgBenchmark` namespace so that users don't have to add it
@@ -238,10 +228,20 @@ function _runbenchmark(file::String, output::String, benchmarkconfig::BenchmarkC
         )
         """
 
+    # Propogate Julia flags passed into the current Julia process
+    color = if VERSION < v"1.5.0-DEV.576"  # https://github.com/JuliaLang/julia/pull/35324
+        Base.have_color ? `--color=yes` : `--color=no`
+    else
+        ``
+    end
+
+    juliacmd = benchmarkconfig.juliacmd
+    juliacmd = `$(Base.julia_cmd(juliacmd[1])) $color $(juliacmd[2:end])`
+
     target_env = [k => v for (k, v) in benchmarkconfig.env]
     withenv(target_env...) do
         env_to_use = dirname(Pkg.Types.Context().env.project_file)
-        run(`$(benchmarkconfig.juliacmd) --project=$env_to_use --depwarn=no --code-coverage=$coverage $color $compilecache -e $exec_str`)
+        run(`$juliacmd --project=$env_to_use --depwarn=no -e $exec_str`)
     end
     return JSON.parsefile(output)
 end


### PR DESCRIPTION
Addresses a failure where `Base.has_color` contains `nothing`. Should address the Windows nightly failure:

```
PkgBenchmark: Running benchmarks...
structure: Error During Test at C:\projects\pkgbenchmark-jl\test\runtests.jl:53
  Got exception outside of a @test
  TypeError: non-boolean (Nothing) used in boolean context
  Stacktrace:
   [1] _runbenchmark(::String, ::String, ::BenchmarkConfig, ::String; retune::Bool, custom_loadpath::String, runoptions::NamedTuple{(:verbose,),Tuple{Bool}}, logger_factory::Nothing) at C:\projects\pkgbenchmark-jl\src\runbenchmark.jl:219
   [2] (::PkgBenchmark.var"#21#23"{Bool,Bool,Nothing,String,String})(::String) at C:\projects\pkgbenchmark-jl\src\runbenchmark.jl:111
   [3] _withtemp(::PkgBenchmark.var"#21#23"{Bool,Bool,Nothing,String,String}, ::String) at C:\projects\pkgbenchmark-jl\src\util.jl:2
   [4] (::PkgBenchmark.var"#do_benchmark#22"{Nothing,Bool,Bool,Nothing,String,String,String,Bool})() at C:\projects\pkgbenchmark-jl\src\runbenchmark.jl:109
   [5] benchmarkpkg(::String, ::BenchmarkConfig; script::Nothing, postprocess::Nothing, resultfile::Nothing, retune::Bool, verbose::Bool, logger_factory::Nothing, progressoptions::Nothing, custom_loadpath::String) at C:\projects\pkgbenchmark-jl\src\runbenchmark.jl:141
   [6] benchmarkpkg at C:\projects\pkgbenchmark-jl\src\runbenchmark.jl:56 [inlined] (repeats 2 times)
   [7] top-level scope at C:\projects\pkgbenchmark-jl\test\runtests.jl:54
   [8] top-level scope at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.5\Test\src\Test.jl:1114
   [9] top-level scope at C:\projects\pkgbenchmark-jl\test\runtests.jl:54
   [10] include(::String) at .\client.jl:457
   [11] top-level scope at none:6
   [12] eval(::Module, ::Any) at .\boot.jl:331
   [13] exec_options(::Base.JLOptions) at .\client.jl:272
   [14] _start() at .\client.jl:506
```
Reference: https://ci.appveyor.com/project/KristofferC/pkgbenchmark-jl/builds/32635975/job/jjymusfo60w0xttv