### PR TITLE
Fix broken link

### DIFF
--- a/docs/src/define_benchmarks.md
+++ b/docs/src/define_benchmarks.md
@@ -1,6 +1,6 @@
 # Defining a benchmark suite
 
-Benchmarks are to be written in `<PKGROOT>/benchmark/benchmarks.jl` and are defined using the standard dictionary based interface from BenchmarkTools, as documented [here](https://github.com/JuliaCI/BenchmarkTools.jl/blob/master/docs/src/manual.md#defining-benchmark-suites). The naming convention that must be used is to name the benchmark suite variable `SUITE`. An example file using the dictionary based interface can be found [here](https://github.com/JuliaCI/PkgBenchmark.jl/blob/master/benchmark/benchmarks.jl). Note that there is no need to have PkgBenchmark loaded to define the benchmark suite.
+Benchmarks are to be written in `<PKGROOT>/benchmark/benchmarks.jl` and are defined using the standard dictionary based interface from BenchmarkTools, as documented [here](https://juliaci.github.io/BenchmarkTools.jl/dev/manual/#Defining-benchmark-suites). The naming convention that must be used is to name the benchmark suite variable `SUITE`. An example file using the dictionary based interface can be found [here](https://github.com/JuliaCI/PkgBenchmark.jl/blob/master/benchmark/benchmarks.jl). Note that there is no need to have PkgBenchmark loaded to define the benchmark suite.
 
 !!! note
     Running this script directly does not actually run the benchmarks, this is the job of PkgBenchmark, see the next section.


### PR DESCRIPTION
This PR fixes a broken link that points to "Defining benchmark suites" in BenchmarkTools.jl's manual.