### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/src/run_benchmarks.md
+++ b/docs/src/run_benchmarks.md
@@ -56,7 +56,7 @@ BenchmarkConfig:
 To benchmark the package with the config, call [`benchmarkpkg`](@ref) as e.g.
 
 ```julia
-benchmark("Tensors", config)
+benchmarkpkg("Tensors", config)
 ```
 
 !!! info


### PR DESCRIPTION
The call should be to `benchmarkpkg`, not `benchmark`.