### PR TITLE
Increase length of short hash to 7

### DIFF
--- a/src/benchmarkjudgement.jl
+++ b/src/benchmarkjudgement.jl
@@ -47,10 +47,10 @@ function Base.show(io::IO, judgement::BenchmarkJudgement)
     println(io, "    Package: ", target.name)
     println(io, "    Dates: ", Dates.format(target.date,  "d u Y - H:M"), " / ",
                                Dates.format(base.date, "d u Y - H:M"))
-    println(io, "    Package commits: ", target.commit[1:min(length(target.commit), 6)], " / ",
-                                        base.commit[1:min(length(base.commit), 6)])
-    println(io, "    Julia commits: ", target.julia_commit[1:6], " / ",
-                                       base.julia_commit[1:6])
+    println(io, "    Package commits: ", shorthash(target.commit), " / ",
+                                         shorthash(base.commit))
+    println(io, "    Julia commits: ", shorthash(target.julia_commit), " / ",
+                                       shorthash(base.julia_commit))
 end
 
 function export_markdown(file::String, results::BenchmarkJudgement; kwargs...)
@@ -87,11 +87,11 @@ function export_markdown(io::IO, judgement::BenchmarkJudgement; export_invariant
                     - Target: $(Dates.format(date(target), "d u Y - HH:MM"))
                     - Baseline: $(Dates.format(date(baseline), "d u Y - HH:MM"))
                 * Package commits:
-                    - Target: $(commit(target)[1:min(6, length(commit(target)))])
-                    - Baseline: $(commit(baseline)[1:min(6, length(commit(baseline)))])
+                    - Target: $(shorthash(commit(target)))
+                    - Baseline: $(shorthash(commit(baseline)))
                 * Julia commits:
-                    - Target: $(juliacommit(target)[1:min(6, length(juliacommit(target)))])
-                    - Baseline: $(juliacommit(baseline)[1:min(6, length(juliacommit(baseline)))])
+                    - Target: $(shorthash(juliacommit(target)))
+                    - Baseline: $(shorthash(juliacommit(baseline)))
                 * Julia command flags:
                     - Target: $(jlstr(target))
                     - Baseline: $(jlstr(baseline))

--- a/src/benchmarkresults.jl
+++ b/src/benchmarkresults.jl
@@ -31,13 +31,15 @@ date(results::BenchmarkResults) = results.date
 benchmarkconfig(results::BenchmarkResults) = results.benchmarkconfig
 InteractiveUtils.versioninfo(results::BenchmarkResults) = results.vinfo
 
+# Length 7 seems to be the minimum such that GitHub and GitLab interpret it as a Git hash:
+shorthash(hash) = hash[1:min(7, length(hash))]
 
 function Base.show(io::IO, results::BenchmarkResults)
     print(io, "Benchmarkresults:\n")
     println(io, "    Package: ", results.name)
     println(io, "    Date: ", Dates.format(results.date, "d u Y - HH:MM"))
-    println(io, "    Package commit: ", results.commit[1:min(length(results.commit), 6)])
-    println(io, "    Julia commit: ", results.julia_commit[1:6])
+    println(io, "    Package commit: ", shorthash(results.commit))
+    println(io, "    Julia commit: ", shorthash(results.julia_commit))
     iob = IOBuffer()
     ioc = IOContext(iob)
     show(ioc, MIME("text/plain"), results.benchmarkgroup)
@@ -124,8 +126,8 @@ function export_markdown(io::IO, results::BenchmarkResults)
 
                 ## Job Properties
                 * Time of benchmark: $(Dates.format(date(results), "d u Y - H:M"))
-                * Package commit: $(commit(results)[1:min(6, length(commit(results)))])
-                * Julia commit: $(juliacommit(results)[1:min(6, length(juliacommit(results)))])
+                * Package commit: $(shorthash(commit(results)))
+                * Julia commit: $(shorthash(juliacommit(results)))
                 * Julia command flags: $julia_command_flags
                 * Environment variables: $env_str
                 """)


### PR DESCRIPTION
which seems to be the minimum length of a string such that both GitHub and GitLab start interpreting it as a Git hash. Example:

- Full hash: 6aab4956fbdf7e79a57cda260a2175bf5e13252a
- Length 7: 6aab495
- Length 6: 6aab49