### PR TITLE
Use consistent date format

### DIFF
--- a/src/benchmarkjudgement.jl
+++ b/src/benchmarkjudgement.jl
@@ -45,8 +45,8 @@ function Base.show(io::IO, judgement::BenchmarkJudgement)
     target, base = judgement.target_results, judgement.baseline_results
     print(io, "Benchmarkjudgement (target / baseline):\n")
     println(io, "    Package: ", target.name)
-    println(io, "    Dates: ", Dates.format(target.date,  "d u Y - H:M"), " / ",
-                               Dates.format(base.date, "d u Y - H:M"))
+    println(io, "    Dates: ", datestr(target), " / ",
+                               datestr(base))
     println(io, "    Package commits: ", target.commit[1:min(length(target.commit), 6)], " / ",
                                         base.commit[1:min(length(base.commit), 6)])
     println(io, "    Julia commits: ", target.julia_commit[1:6], " / ",
@@ -84,8 +84,8 @@ function export_markdown(io::IO, judgement::BenchmarkJudgement; export_invariant
 
                 ## Job Properties
                 * Time of benchmarks:
-                    - Target: $(Dates.format(date(target), "d u Y - HH:MM"))
-                    - Baseline: $(Dates.format(date(baseline), "d u Y - HH:MM"))
+                    - Target: $(datestr(target))
+                    - Baseline: $(datestr(baseline))
                 * Package commits:
                     - Target: $(commit(target)[1:min(6, length(commit(target)))])
                     - Baseline: $(commit(baseline)[1:min(6, length(commit(baseline)))])

--- a/src/benchmarkresults.jl
+++ b/src/benchmarkresults.jl
@@ -28,6 +28,7 @@ commit(results::BenchmarkResults) = results.commit
 juliacommit(results::BenchmarkResults) = results.julia_commit
 benchmarkgroup(results::BenchmarkResults) = results.benchmarkgroup
 date(results::BenchmarkResults) = results.date
+datestr(results::BenchmarkResults) = Dates.format(date(results), "d u Y - HH:MM")
 benchmarkconfig(results::BenchmarkResults) = results.benchmarkconfig
 InteractiveUtils.versioninfo(results::BenchmarkResults) = results.vinfo
 
@@ -35,7 +36,7 @@ InteractiveUtils.versioninfo(results::BenchmarkResults) = results.vinfo
 function Base.show(io::IO, results::BenchmarkResults)
     print(io, "Benchmarkresults:\n")
     println(io, "    Package: ", results.name)
-    println(io, "    Date: ", Dates.format(results.date, "d u Y - HH:MM"))
+    println(io, "    Date: ", datestr(results))
     println(io, "    Package commit: ", results.commit[1:min(length(results.commit), 6)])
     println(io, "    Julia commit: ", results.julia_commit[1:6])
     iob = IOBuffer()
@@ -123,7 +124,7 @@ function export_markdown(io::IO, results::BenchmarkResults)
                 # Benchmark Report for *$(name(results))*
 
                 ## Job Properties
-                * Time of benchmark: $(Dates.format(date(results), "d u Y - H:M"))
+                * Time of benchmark: $(datestr(results))
                 * Package commit: $(commit(results)[1:min(6, length(commit(results)))])
                 * Julia commit: $(juliacommit(results)[1:min(6, length(juliacommit(results)))])
                 * Julia command flags: $julia_command_flags


### PR DESCRIPTION
Some used `H:M`, which does not look sane to me.