### PR TITLE
Allow for benchmarking with MPI

### DIFF
--- a/src/runbenchmark.jl
+++ b/src/runbenchmark.jl
@@ -249,7 +249,7 @@ function _runbenchmark(file::String, output::String, benchmarkconfig::BenchmarkC
     end
 
     juliacmd = benchmarkconfig.juliacmd
-    juliacmd = `$(Base.julia_cmd(juliacmd[1])) $color $(juliacmd[2:end])`
+    juliacmd = `$(Base.julia_cmd(juliacmd)) $color`
 
     target_env = [k => v for (k, v) in benchmarkconfig.env]
     withenv(target_env...) do
@@ -291,12 +291,16 @@ function __runbenchmark_local(file, output, tunefile, retune, runoptions)
     vinfo = first(split(sprint((io) -> versioninfo(io; verbose=true)), "Environment"))
     juliasha = Base.GIT_VERSION_INFO.commit
 
-    open(output, "w") do iof
+    # Atomic write to the output file
+    temp_output = tempname()
+    open(temp_output, "w") do iof
         JSON.print(iof, Dict(
             "results"  => sprint(BenchmarkTools.save, results),
             "vinfo"    => vinfo,
             "juliasha" => juliasha,
         ))
     end
+    mv(temp_output, output; force=true)
+
     return nothing
 end


### PR DESCRIPTION
I've been trying to enable MPI benchmarks on a package I help develop. As things stand, it is seemingly impossible. In this PR, I propose two minor changes that would allow this feature. These amendments are general and do not explicitly depend on `MPI.jl`. They do not change the behavior of `PkgBenchmark` in any other case.

1) To run a MPI benchmark, I'd like to pass the following `juliacmd` to `BenchmarkConfig()`:
```
juliacmd = `$(mpiexec()) -n $n_ranks $(joinpath(Sys.BINDIR, Base.julia_exename()))`
```
Because of the way the [--color](https://github.com/JuliaCI/PkgBenchmark.jl/blob/6b7222c6ea8bea2dd1e8109a11b25c0c0760729e/src/runbenchmark.jl#L244-L252) flag is dealt with, the `-C`, `-J` and `-g1` flags are passed to `mpiexec` causing an error. Since the orders of the flags does not matter, I propose to simply append `--color` at the end of `juliacmd` rather than after the first word.

2) Benchmark results are written to a temporary file, before it is parsed to a JSON dictionary. With MPI, each rank will write to the same file, causing a race condition. To solve this issue, I propose to use atomic writes as inspired by this PR: JuliaLang/Pkg.jl/pull/3235. Each rank will overwrite the same information in turn (assuming a barrier near the end of the application). 

Note that each rank logs the benchmark progress, and the terminal can get a little crowded. This is not much of an issue, as the benchmark report is unique and correct.

Thanks for considering this contribution.